### PR TITLE
Don't try to parse "data" if it's None

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -160,7 +160,7 @@ class PaginatedList(PaginatedListBase):
         data = data if data else []
 
         self.__nextUrl = None
-        if len(data) > 0:
+        if data and len(data) > 0:
             links = self.__parseLinkHeader(headers)
             if self._reversed:
                 if "prev" in links:
@@ -169,14 +169,16 @@ class PaginatedList(PaginatedListBase):
                 self.__nextUrl = links["next"]
         self.__nextParams = None
 
-        if 'items' in data:
+        if data and 'items' in data:
             self.__totalCount = data['total_count']
             data = data["items"]
-
-        content = [
-            self.__contentClass(self.__requester, headers, element, completed=False)
-            for element in data if element is not None
-        ]
+        if data is None:
+          content = []
+        else:
+          content = [
+              self.__contentClass(self.__requester, headers, element, completed=False)
+              for element in data if element is not None
+          ]
         if self._reversed:
             return content[::-1]
         return content


### PR DESCRIPTION
I suspect this is related to the cause of
https://github.com/PyGithub/PyGithub/issues/278#issuecomment-58292338 in
that the response from the github API contains null for some elements.

With more time I'd like to capture the response from github to find out which elements are missing, and perhaps even work out in what situations they are absent. Two things of note:
1. The versioned release of the parent repo is quite old - there is ~1 year of commits since our fork.
   That repo has some discussion (in https://github.com/PyGithub/PyGithub/issues/297) seeking another maintainer(s). It means that in the short term we're not likely to get our work merged into that repo, and so should consider using our fork.
2. This fix sits atop all of that work - most of that is catching other null de-referencing issues such as this so we'll be bitten less often by other partially-missing responses.
